### PR TITLE
Fix f-string with escaped quotes

### DIFF
--- a/quietpatch/report/html.py
+++ b/quietpatch/report/html.py
@@ -193,13 +193,21 @@ def generate_report(input_path: str, output_path: str) -> str:
         row_id = f"row-{i}"
         has_cves = bool(vulns)
 
+        # Compute severity badge and inferred star separately
+        inferred = bool(
+            rec.get("inferred")
+            or (rec.get("severity_source") in {"vector", "vendor", "epss", "kev", "cwe", "floor"})
+        )
+        badge = _sev_badge(sev or (rec.get("severity_label") or ""))
+        sup = '<sup title="inferred from policy">*</sup>' if inferred else ""
+
         cells = [
             f'<td class="app-cell">{html.escape(str(app))}</td>',
             f'<td class="version-cell">{html.escape(str(ver))}</td>',
             _action_cell(rec),  # <-- Action column with copy buttons
             f'<td class="cve-cell">{html.escape(str(cve or "—"))}</td>',
             f'<td class="cvss-cell">{html.escape(str(cvss or "—"))}</td>',
-            f'<td class="severity-cell">{_sev_badge(sev or (rec.get("severity_label") or ""))}</td>',
+            f'<td class="severity-cell">{badge}{sup}</td>',
             f'<td class="kev-cell">{html.escape(kev or "—")}</td>',
             f'<td class="epss-cell">{html.escape(epss or "—")}</td>',
             f'<td class="summary-cell">{html.escape(summary or "")}</td>',


### PR DESCRIPTION
Precompute inferred severity star HTML to fix f-string backslash syntax error.

---
<a href="https://cursor.com/background-agent?bcId=bc-e6f11a8d-a22e-4e85-ba46-3e0373388ea5">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-e6f11a8d-a22e-4e85-ba46-3e0373388ea5">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

