### PR TITLE
Add policy presets, json export, and landing page

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,60 @@
+---
+title: QuietPatch
+layout: default
+---
+
+<h1>QuietPatch 🔐</h1>
+<p>Privacy-first vulnerability scanner with deterministic HTML reports and actionable remediation. Runs fully offline.</p>
+
+## Install
+
+**macOS / Linux**
+```bash
+/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Matt-C-G/QuietPatch/main/install.sh)"
+```
+
+**Windows (PowerShell)**
+
+```powershell
+irm https://raw.githubusercontent.com/Matt-C-G/QuietPatch/main/install.ps1 | iex
+```
+
+Or via package managers:
+
+* **Homebrew**
+
+```bash
+brew tap matt-c-g/quietpatch && brew install quietpatch
+```
+
+* **Scoop**
+
+```powershell
+scoop bucket add quietpatch https://github.com/Matt-C-G/scoop-quietpatch
+scoop install quietpatch
+```
+
+## Quickstart
+
+```bash
+quietpatch scan --db ./db-latest.tar.zst --also-report --open
+```
+
+The report opens in your browser with app inventory, CVEs (KEV, CVSS, EPSS), and concrete remediation steps.
+
+## Verify
+
+Always verify downloads:
+
+```bash
+shasum -a 256 -c SHA256SUMS
+```
+
+See <code>VERIFY.md</code> for minisign signature verification.
+
+---
+
+<p align="center">
+  <img src="assets/screenshot-report.png" alt="QuietPatch Report" width="820" />
+  </p>
+

--- a/policies/policy-conservative.yml
+++ b/policies/policy-conservative.yml
@@ -1,0 +1,12 @@
+# Enterprise-friendly, fewer findings
+allow: []
+deny:  []
+min_severity: high
+treat_unknown_as: low
+max_unknown_ratio: 0.0
+unknown_strategy: infer
+only_with_cves: true
+limit_per_app: 30
+sort:
+  kev_first: true
+  by: [severity, epss_desc, cvss_desc, cve_id_asc]

--- a/policies/policy-critical-only.yml
+++ b/policies/policy-critical-only.yml
@@ -1,0 +1,12 @@
+# Triage mode, only critical (KEV promoted)
+allow: []
+deny:  []
+min_severity: critical
+treat_unknown_as: low
+max_unknown_ratio: 0.0
+unknown_strategy: infer
+only_with_cves: true
+limit_per_app: 20
+sort:
+  kev_first: true
+  by: [kev_desc, cvss_desc, epss_desc, cve_id_asc]

--- a/policies/policy-default.yml
+++ b/policies/policy-default.yml
@@ -1,0 +1,12 @@
+# Default, balanced
+allow: []
+deny:  []
+min_severity: medium         # low | medium | high | critical
+treat_unknown_as: low        # legacy floor; DB build should already eliminate "unknown"
+max_unknown_ratio: 0.0       # enforce zero unknowns in reports
+unknown_strategy: infer      # infer | drop | fail
+only_with_cves: true
+limit_per_app: 50
+sort:
+  kev_first: true
+  by: [severity, cvss_desc, epss_desc, cve_id_asc]

--- a/quietpatch/report/jsonout.py
+++ b/quietpatch/report/jsonout.py
@@ -1,0 +1,62 @@
+from __future__ import annotations
+from typing import Any, Dict, Iterable, Mapping
+import json, time
+
+def to_json(apps: Iterable[Mapping[str, Any]], policy: Mapping[str, Any], meta: Mapping[str, Any] | None = None) -> str:
+    """
+    Produce a stable, machine-readable JSON.
+    Expected 'apps' items shape:
+      { name, version, vendor?, cves: [ {id, severity, cvss?, epss?, kev?, summary?, action? } ] }
+    """
+    ts = int(time.time())
+    doc = {
+        "schema": "quietpatch.report/v1",
+        "generated_at_utc": ts,
+        "policy": policy or {},
+        "meta": meta or {},
+        "summary": _summarize(apps),
+        "apps": _normalize_apps(apps),
+    }
+    return json.dumps(doc, sort_keys=True, separators=(",", ":"))
+
+def _summarize(apps: Iterable[Mapping[str, Any]]) -> Dict[str, int]:
+    counts = {"apps":0,"vuln_apps":0,"critical":0,"high":0,"medium":0,"low":0,"kev":0,"unknown":0}
+    for app in apps or []:
+        counts["apps"] += 1
+        cves = app.get("cves") or []
+        if cves:
+            counts["vuln_apps"] += 1
+        for c in cves:
+            sev = (c.get("severity") or "").lower()
+            if sev not in ("critical","high","medium","low"):
+                sev = "unknown"
+            counts[sev] += 1
+            if c.get("kev") is True or c.get("is_kev") is True:
+                counts["kev"] += 1
+    return counts
+
+def _normalize_apps(apps: Iterable[Mapping[str, Any]]) -> list[dict]:
+    out = []
+    for a in apps or []:
+        row = {
+            "name": a.get("name") or a.get("app") or a.get("app_name"),
+            "version": a.get("version"),
+            "vendor": a.get("vendor"),
+            "cves": [],
+        }
+        # Support both 'cves' and 'vulnerabilities' keys
+        vulns = a.get("cves")
+        if not vulns:
+            vulns = a.get("vulnerabilities") or []
+        for c in vulns or []:
+            row["cves"].append({
+                "id": c.get("id") or c.get("cve_id"),
+                "severity": (c.get("severity") or "low").lower(),
+                "cvss": c.get("cvss"),
+                "epss": c.get("epss"),
+                "kev": bool(c.get("kev") or c.get("is_kev")),
+                "summary": c.get("summary"),
+                "action": c.get("action") or c.get("actions"),
+            })
+        out.append(row)
+    return out


### PR DESCRIPTION
Introduce sample policy presets, a machine-readable JSON report export, and a GitHub Pages landing page to enhance user experience and integration.

These changes provide users with immediate policy presets, offer a stable JSON output for easier integration, and establish a clean landing page for better first-time adoption.

---
<a href="https://cursor.com/background-agent?bcId=bc-6a7b471a-4d44-4d0b-911a-4a0df0b91270">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-6a7b471a-4d44-4d0b-911a-4a0df0b91270">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

